### PR TITLE
i18n infrastructure + L33T as the first secondary locale

### DIFF
--- a/e2e/i18n-catalog.test.ts
+++ b/e2e/i18n-catalog.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { MESSAGES } from '../src/lib/i18n/messages';
+import { l33t } from '../src/lib/i18n/catalogs/l33t';
+import { translate } from '../src/lib/i18n/translate';
+
+// Guards the authored L33T catalog. Completeness is also enforced at compile time
+// by `Record<Message, string>`; these run the same checks at runtime and add the
+// qualities the type system can't express (real translations, no orphans).
+
+test.describe('L33T message catalog', () => {
+	test('every catalogued message has an authored translation that is actually used', () => {
+		const missing = MESSAGES.filter((m) => !l33t[m]);
+		expect(missing).toEqual([]);
+
+		// translate() returns the authored value, not the algorithmic fallback.
+		for (const m of MESSAGES) {
+			expect(translate(m, 'l33t')).toBe(l33t[m]);
+		}
+	});
+
+	test('every translation differs from its English source', () => {
+		const unchanged = MESSAGES.filter((m) => l33t[m] === m);
+		expect(unchanged).toEqual([]);
+	});
+
+	test('the catalog has no keys outside the canonical message list', () => {
+		const known = new Set<string>(MESSAGES);
+		const orphans = Object.keys(l33t).filter((key) => !known.has(key));
+		expect(orphans).toEqual([]);
+	});
+});

--- a/e2e/i18n-transform.test.ts
+++ b/e2e/i18n-transform.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { toLeet } from '../src/lib/i18n/leet';
+import { translate } from '../src/lib/i18n/translate';
+
+// Pure unit coverage of the translation layer. These specs never touch a `page`
+// — they import the runes-free i18n modules directly, which is only possible
+// because `leet.ts`/`translate.ts` are deliberately kept free of Svelte runes.
+
+test.describe('Translation layer (pure)', () => {
+	test('English is the identity function (the output-preserving invariant)', () => {
+		const samples = ['Before you begin', 'Start box breathing', 'Inhale', '', '12.4s · 2:00 left'];
+		for (const s of samples) {
+			expect(translate(s, 'en')).toBe(s);
+		}
+	});
+
+	test('L33T falls back to the leet transform for uncatalogued strings', () => {
+		// Not a catalogued message, so it exercises the algorithmic fallback path.
+		const novel = 'Zephyr Quux 42';
+		expect(translate(novel, 'l33t')).toBe(toLeet(novel));
+	});
+
+	test('leet substitutes the documented look-alike letters', () => {
+		// a→4 b→8 e→3 g→9 i→1 l→1 o→0 s→5 t→7
+		expect(toLeet('aebgilost')).toBe('438911057');
+	});
+
+	test('leet is case-insensitive and preserves length', () => {
+		expect(toLeet('AEIOU')).toBe('4310U');
+		expect(toLeet('Hello World')).toHaveLength('Hello World'.length);
+	});
+
+	test('digits, punctuation and whitespace pass through untouched', () => {
+		const noLetters = '2:00 · (2023)! — +/-';
+		expect(toLeet(noLetters)).toBe(noLetters);
+	});
+
+	test('the transform is deterministic', () => {
+		const s = 'Box Breathing protocol';
+		expect(toLeet(s)).toBe(toLeet(s));
+	});
+});

--- a/e2e/i18n.test.ts
+++ b/e2e/i18n.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { translate } from '../src/lib/i18n/translate';
+
+// Expected localized copy is computed via the *same* translator the app uses, so
+// these assertions can never drift from the transform's output.
+const leetHeading = translate('Before you begin', 'l33t');
+
+test.describe('Internationalization', () => {
+	test('?lang=l33t switches <html lang> and renders leetspeak copy', async ({ page }) => {
+		await page.goto('/?lang=l33t');
+		await expect(page.locator('html')).toHaveAttribute('lang', 'en-x-l33t');
+		await expect(page.locator('h1')).toHaveText(leetHeading);
+	});
+
+	test('the header switcher transforms copy live and persists across reloads', async ({ page }) => {
+		await page.goto('/');
+		// Default locale is English — the existing suite depends on this.
+		await expect(page.locator('h1')).toHaveText('Before you begin');
+
+		await page.getByLabel('Language').selectOption('l33t');
+		await expect(page.locator('h1')).toHaveText(leetHeading);
+		await expect(page.locator('html')).toHaveAttribute('lang', 'en-x-l33t');
+
+		const stored = await page.evaluate(() => window.localStorage.getItem('locale'));
+		expect(stored).toBe('l33t');
+
+		await page.reload();
+		await expect(page.locator('h1')).toHaveText(leetHeading);
+	});
+
+	test('the flow still works in L33T using locale-aware selectors', async ({ page }) => {
+		await page.goto('/?lang=l33t');
+		// Accessible names are leeted, so derive them from the same translator
+		// rather than hardcoding — selecting by role keeps the structure stable.
+		await page.getByRole('checkbox').check();
+		await page.getByRole('button', { name: translate('Acknowledge & continue', 'l33t') }).click();
+		await expect(page.locator('h1')).toHaveCount(0);
+	});
+
+	test('an unknown ?lang= falls back to English', async ({ page }) => {
+		await page.goto('/?lang=bogus');
+		await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+		await expect(page.locator('h1')).toHaveText('Before you begin');
+	});
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,10 @@ export default ts.config(
 		}
 	},
 	{
-		files: ['**/*.svelte'],
+		// Components and Svelte runes modules (*.svelte.ts / *.svelte.js) are parsed by
+		// svelte-eslint-parser; point its script sub-parser at typescript-eslint so the
+		// TypeScript syntax in those files parses correctly.
+		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 
 		languageOptions: {
 			parserOptions: {

--- a/src/app.html
+++ b/src/app.html
@@ -16,7 +16,6 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>Carbon Dioxide Tolerance Testing & Training Tool</title>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/BoxBreathing.svelte
+++ b/src/lib/BoxBreathing.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import Button from '$lib/Button.svelte';
 	import { createTimer } from '$lib/clock.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { interval, onDone, onEnd }: { interval: number; onDone: () => void; onEnd: () => void } =
 		$props();
@@ -62,8 +63,8 @@
 
 <div class="col between breathe">
 	<div class="bar">
-		<span class="mono accent">Box breathing</span>
-		<span class="mono muted">{interval}s · {mm}:{ss} left</span>
+		<span class="mono accent">{t('Box breathing')}</span>
+		<span class="mono muted">{interval}s · {mm}:{ss} {t('left')}</span>
 	</div>
 
 	<div class="stage">
@@ -78,8 +79,8 @@
 			<span class="tick br"></span>
 		</div>
 		<div class="center">
-			<span class="phase">{ph.label}</span>
-			<span class="phase-sub">{ph.sub}</span>
+			<span class="phase">{t(ph.label)}</span>
+			<span class="phase-sub">{t(ph.sub)}</span>
 			<span class="phase-count">{secLeft}</span>
 		</div>
 	</div>
@@ -90,7 +91,7 @@
 				<span class="dot" class:on={i === idx}></span>
 			{/each}
 		</div>
-		<Button variant="ghost" size="sm" onclick={onEnd}>End session</Button>
+		<Button variant="ghost" size="sm" onclick={onEnd}>{t('End session')}</Button>
 	</div>
 </div>
 

--- a/src/lib/Done.svelte
+++ b/src/lib/Done.svelte
@@ -2,6 +2,7 @@
 	import ElementTile from '$lib/ElementTile.svelte';
 	import Button from '$lib/Button.svelte';
 	import Icon from '$lib/Icon.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { exhaleMs, interval, onRestart } = $props();
 
@@ -13,21 +14,22 @@
 </script>
 
 <div class="col center done">
-	<div class="badge"><ElementTile sym="✓" name="Complete" size={64} /></div>
-	<h2>Great job</h2>
-	<p class="lede">You completed a full two-minute box-breathing cycle.</p>
+	<div class="badge"><ElementTile sym="✓" name={t('Complete')} size={64} /></div>
+	<h2>{t('Great job')}</h2>
+	<p class="lede">{t('You completed a full two-minute box-breathing cycle.')}</p>
 
 	<div class="stats">
 		{#each stats as [k, v] (k)}
 			<div class="stat">
 				<div class="stat-v">{v}</div>
-				<span class="mono stat-k">{k}</span>
+				<span class="mono stat-k">{t(k)}</span>
 			</div>
 		{/each}
 	</div>
 
 	<Button full variant="secondary" onclick={onRestart}>
-		<Icon name="restart" size={17} /> Start over
+		<Icon name="restart" size={17} />
+		{t('Start over')}
 	</Button>
 </div>
 

--- a/src/lib/ExhaleTest.svelte
+++ b/src/lib/ExhaleTest.svelte
@@ -3,6 +3,7 @@
 	import Icon from '$lib/Icon.svelte';
 	import { createTimer } from '$lib/clock.svelte';
 	import { isValidExhale } from '$lib/calibration';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { onResult }: { onResult: (ms: number) => void } = $props();
 
@@ -27,8 +28,8 @@
 
 <div class="col between exhale">
 	<div class="head">
-		<span class="mono step">Step 01 · Exhale test</span>
-		<h2>{timer.running ? 'Exhale as slowly as you can' : 'Measure your slowest exhale'}</h2>
+		<span class="mono step">{t('Step 01 · Exhale test')}</span>
+		<h2>{timer.running ? t('Exhale as slowly as you can') : t('Measure your slowest exhale')}</h2>
 	</div>
 
 	<div class="meter">
@@ -41,10 +42,12 @@
 		</div>
 		<p class="guide">
 			{#if timer.running}
-				Tap <strong>Stop</strong> the moment you run out of air. Don’t hold your breath.
+				{t('Tap')} <strong>{t('Stop')}</strong>
+				{t('the moment you run out of air. Don’t hold your breath.')}
 			{:else}
-				Inhale completely through your nose. Then start the timer and let the air out as slowly as
-				possible.
+				{t(
+					'Inhale completely through your nose. Then start the timer and let the air out as slowly as possible.'
+				)}
 			{/if}
 		</p>
 	</div>
@@ -55,7 +58,7 @@
 		variant={timer.running ? 'secondary' : 'primary'}
 		onclick={timer.running ? stop : start}
 	>
-		{timer.running ? 'Stop' : 'Start'}
+		{timer.running ? t('Stop') : t('Start')}
 	</Button>
 </div>
 

--- a/src/lib/LocaleSwitcher.svelte
+++ b/src/lib/LocaleSwitcher.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { locale, t } from '$lib/i18n/locale.svelte';
+	import { LOCALES, isLocale } from '$lib/i18n/locales';
+
+	function onchange(event: Event) {
+		const value = (event.currentTarget as HTMLSelectElement).value;
+		if (isLocale(value)) locale.set(value);
+	}
+</script>
+
+<select class="lang" aria-label={t('Language')} value={locale.current} {onchange}>
+	{#each LOCALES as l (l.code)}
+		<option value={l.code}>{l.endonym}</option>
+	{/each}
+</select>
+
+<style>
+	.lang {
+		appearance: none;
+		border: 1px solid var(--line);
+		background: transparent;
+		color: var(--muted);
+		font-family: var(--font-mono);
+		font-size: 11px;
+		border-radius: 7px;
+		padding: 4px 7px;
+		cursor: pointer;
+		transition:
+			color 0.15s,
+			border-color 0.15s;
+	}
+
+	.lang:hover {
+		color: var(--accent);
+		border-color: var(--accent);
+	}
+</style>

--- a/src/lib/Reset.svelte
+++ b/src/lib/Reset.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import { createTimer } from '$lib/clock.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { sub = 'Rest before the next step.', onDone, onSkip } = $props();
 
@@ -43,9 +44,9 @@
 		</div>
 	</div>
 
-	<h2>Breathe normally</h2>
-	<p class="sub">{sub} Ideally through the nose.</p>
-	<button class="skip mono" onclick={onSkip}>Skip →</button>
+	<h2>{t('Breathe normally')}</h2>
+	<p class="sub">{sub} {t('Ideally through the nose.')}</p>
+	<button class="skip mono" onclick={onSkip}>{t('Skip →')}</button>
 </div>
 
 <style>

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import Icon from '$lib/Icon.svelte';
 	import { theme } from '$lib/theme.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 </script>
 
 <button
 	class="icon-btn"
 	data-theme-toggle
-	aria-label={theme.mode === 'dark' ? 'Change to light theme.' : 'Change to dark theme.'}
+	aria-label={theme.mode === 'dark' ? t('Change to light theme.') : t('Change to dark theme.')}
 	onclick={() => theme.toggle()}
 >
 	<Icon name={theme.mode === 'dark' ? 'sun' : 'moon'} size={18} />

--- a/src/lib/TimeConversion.svelte
+++ b/src/lib/TimeConversion.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte';
 	import Button from '$lib/Button.svelte';
 	import { exhaleToInterval, MIN_INTERVAL_S, MAX_INTERVAL_S } from '$lib/calibration';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { milliseconds, onStart }: { milliseconds: number; onStart: (secs: number) => void } =
 		$props();
@@ -22,33 +23,34 @@
 
 <div class="col between calibrate">
 	<div class="head">
-		<span class="mono step">Step 02 · Calibration</span>
-		<h2>Set your interval</h2>
+		<span class="mono step">{t('Step 02 · Calibration')}</span>
+		<h2>{t('Set your interval')}</h2>
 		<p class="lede">
-			Calibrated from your <strong>{exhaleSecs}s</strong> exhale. Each phase will last this long.
+			{t('Calibrated from your')} <strong>{exhaleSecs}s</strong>
+			{t('exhale. Each phase will last this long.')}
 		</p>
 	</div>
 
 	<div class="stepper">
 		<button
 			class="round"
-			aria-label="Decrease interval"
+			aria-label={t('Decrease interval')}
 			onclick={dec}
 			disabled={secs <= MIN_INTERVAL_S}>–</button
 		>
 		<div class="value-wrap">
 			<div class="value" data-testid="interval">{secs}</div>
-			<span class="mono unit">seconds</span>
+			<span class="mono unit">{t('seconds')}</span>
 		</div>
 		<button
 			class="round"
-			aria-label="Increase interval"
+			aria-label={t('Increase interval')}
 			onclick={inc}
 			disabled={secs >= MAX_INTERVAL_S}>+</button
 		>
 	</div>
 
-	<Button full size="lg" onclick={() => onStart(secs)}>Start box breathing</Button>
+	<Button full size="lg" onclick={() => onStart(secs)}>{t('Start box breathing')}</Button>
 </div>
 
 <style>

--- a/src/lib/Warning.svelte
+++ b/src/lib/Warning.svelte
@@ -2,10 +2,13 @@
 	import ElementTile from '$lib/ElementTile.svelte';
 	import Button from '$lib/Button.svelte';
 	import Icon from '$lib/Icon.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	let { onAccept } = $props();
 	let ok = $state(false);
 
+	// English source strings double as keys; t() is applied at the usage site so
+	// the list stays the source of truth and re-renders on locale change.
 	const disclaimers = [
 		'For educational use only. Not medical advice.',
 		'Consult a licensed physician before any breathing exercise.',
@@ -16,26 +19,27 @@
 <div class="col between warning">
 	<div class="intro">
 		<div class="tiles">
-			<ElementTile sym="C" num="6" name="A Box" size={50} />
-			<ElementTile sym="O²" num="8" name="Breathing" size={50} />
-			<ElementTile sym="T⁴" num="22" name="Tool" size={50} />
+			<ElementTile sym="C" num="6" name={t('A Box')} size={50} />
+			<ElementTile sym="O²" num="8" name={t('Breathing')} size={50} />
+			<ElementTile sym="T⁴" num="22" name={t('Tool')} size={50} />
 		</div>
-		<h1>Before you begin</h1>
+		<h1>{t('Before you begin')}</h1>
 		<p class="lede">
-			A guide to the <strong>Box Breathing</strong> protocol from
+			{t('A guide to the')} <strong>{t('Box Breathing')}</strong>
+			{t('protocol from')}
 			<a href="https://doi.org/10.1016/j.xcrm.2022.100895" target="_blank" rel="noreferrer"
-				>Balban et&nbsp;al. (2023)</a
-			>.
+				>{t('Balban et al. (2023)')}</a
+			>{t('.')}
 		</p>
 	</div>
 
 	<div class="disclaimer">
 		<div class="dis-head">
 			<Icon name="info" size={16} stroke="var(--danger)" />
-			<span class="mono dis-tag">Medical disclaimer</span>
+			<span class="mono dis-tag">{t('Medical disclaimer')}</span>
 		</div>
 		{#each disclaimers as d (d)}
-			<div class="bullet"><span class="dash">—</span><span>{d}</span></div>
+			<div class="bullet"><span class="dash">—</span><span>{t(d)}</span></div>
 		{/each}
 	</div>
 
@@ -44,19 +48,21 @@
 			<input type="checkbox" bind:checked={ok} />
 			<span class="box"></span>
 			<span class="check-text"
-				>I understand this is an unofficial tool offered with no warranty, and I accept full
-				responsibility for my use of it.</span
+				>{t(
+					'I understand this is an unofficial tool offered with no warranty, and I accept full responsibility for my use of it.'
+				)}</span
 			>
 		</label>
-		<Button full disabled={!ok} onclick={onAccept}>Acknowledge &amp; continue</Button>
+		<Button full disabled={!ok} onclick={onAccept}>{t('Acknowledge & continue')}</Button>
 		<div class="meta">
-			<a href="https://github.com/matthewnoel/CO2T4" target="_blank" rel="noreferrer">Source code</a
+			<a href="https://github.com/matthewnoel/CO2T4" target="_blank" rel="noreferrer"
+				>{t('Source code')}</a
 			>
 			<span aria-hidden="true">·</span>
 			<a
 				href="https://github.com/matthewnoel/CO2T4/blob/main/third-party-licenses.txt"
 				target="_blank"
-				rel="noreferrer">Third-party licenses</a
+				rel="noreferrer">{t('Third-party licenses')}</a
 			>
 		</div>
 	</div>

--- a/src/lib/i18n/catalogs/l33t.ts
+++ b/src/lib/i18n/catalogs/l33t.ts
@@ -1,0 +1,93 @@
+import type { Message } from '../messages';
+
+// Authored L33T (leetspeak) for every catalogued message. House style: uppercase
+// with the classic digit substitutions (A→4 B→8 E→3 G→9 I→1 L→1 O→0 S→5 T→7)
+// plus a few iconic word swaps (you→J00, your→J00R, to→2, for→4).
+//
+// Typed as Record<Message, string>, so a missing translation — or a key that
+// isn't a real message — is a compile-time error. Anything not listed here (the
+// Balban citation, punctuation, numbers) is handled by the algorithmic transform
+// fallback in translate().
+export const l33t: Record<Message, string> = {
+	// Warning
+	'A Box': '4 80X',
+	Breathing: '8R347H1N9',
+	Tool: '7001',
+	'Before you begin': '83F0R3 J00 83G1N',
+	'A guide to the': '4 9U1D3 2 7H3',
+	'Box Breathing': '80X 8R347H1N9',
+	'protocol from': 'PR070C01 FR0M',
+	'Medical disclaimer': 'M3D1C41 D15C141M3R',
+	'For educational use only. Not medical advice.': '4 3DUC4710N41 U53 0N1Y. N07 M3D1C41 4DV1C3.',
+	'Consult a licensed physician before any breathing exercise.':
+		'C0N5U17 4 11C3N53D PHY51C14N 83F0R3 4NY 8R347H1N9 3X3RC153.',
+	'Not affiliated with the study’s authors. No warranty.':
+		'N07 4FF111473D W17H 7H3 57UDY’5 4U7H0R5. N0 W4RR4N7Y.',
+	'I understand this is an unofficial tool offered with no warranty, and I accept full responsibility for my use of it.':
+		'1 UND3R574ND 7H15 15 4N UN0FF1C141 7001 0FF3R3D W17H N0 W4RR4N7Y, 4ND 1 4CC3P7 FU11 R35P0N5181117Y 4 MY U53 0F 17.',
+	'Acknowledge & continue': '4CKN0WL3D93 & C0N71NU3',
+	'Source code': '50URC3 C0D3',
+	'Third-party licenses': '7H1RD-P4R7Y 11C3N535',
+
+	// App shell
+	'Carbon Dioxide Tolerance Testing & Training Tool':
+		'C4R80N D10X1D3 7013R4NC3 73571N9 & 7R41N1N9 7001',
+	Back: '84CK',
+	'Settle in for the exhale test.': '537713 1N 4 7H3 3XH413 7357.',
+	'Recover before you calibrate.': 'R3C0V3R 83F0R3 J00 C41184R473.',
+
+	// Exhale test
+	'Step 01 · Exhale test': '573P 01 · 3XH413 7357',
+	'Exhale as slowly as you can': '3XH413 45 510W1Y 45 J00 C4N',
+	'Measure your slowest exhale': 'M345UR3 J00R 510W357 3XH413',
+	Tap: '74P',
+	Stop: '570P',
+	'the moment you run out of air. Don’t hold your breath.':
+		'7H3 M0M3N7 J00 RUN 0U7 0F 41R. D0N’7 H01D J00R 8R347H.',
+	'Inhale completely through your nose. Then start the timer and let the air out as slowly as possible.':
+		'1NH413 C0MP13731Y 7HR0U9H J00R N053. 7H3N 574R7 7H3 71M3R 4ND 137 7H3 41R 0U7 45 510W1Y 45 P0551813.',
+	Start: '574R7',
+
+	// Calibration
+	'Step 02 · Calibration': '573P 02 · C41184R4710N',
+	'Set your interval': '537 J00R 1N73RV41',
+	'Calibrated from your': 'C41184R473D FR0M J00R',
+	'exhale. Each phase will last this long.': '3XH413. 34CH PH453 W111 1457 7H15 10N9.',
+	'Decrease interval': 'D3CR3453 1N73RV41',
+	seconds: '53C0ND5',
+	'Increase interval': '1NCR3453 1N73RV41',
+	'Start box breathing': '574R7 80X 8R347H1N9',
+
+	// Rest
+	'Breathe normally': '8R347H3 N0RM411Y',
+	'Ideally through the nose.': '1D3411Y 7HR0U9H 7H3 N053.',
+	'Skip →': '5K1P →',
+
+	// Box breathing
+	'Box breathing': '80X 8R347H1N9',
+	left: '13F7',
+	Inhale: '1NH413',
+	'through your nose': '7HR0U9H J00R N053',
+	Hold: 'H01D',
+	'keep it in': 'K33P 17 1N',
+	Exhale: '3XH413',
+	'slow and steady': '510W 4ND 5734DY',
+	'stay empty': '574Y 3MP7Y',
+	'End session': '3ND 535510N',
+
+	// Done
+	Complete: 'C0MP1373',
+	'Great job': '9R347 J08',
+	'You completed a full two-minute box-breathing cycle.':
+		'J00 C0MP1373D 4 FU11 7W0-M1NU73 80X-8R347H1N9 CYC13.',
+	Interval: '1N73RV41',
+	Duration: 'DUR4710N',
+	'Start over': '574R7 0V3R',
+
+	// Theme toggle
+	'Change to light theme.': 'CH4N93 2 119H7 7H3M3.',
+	'Change to dark theme.': 'CH4N93 2 D4RK 7H3M3.',
+
+	// Locale switcher
+	Language: '14N9U493'
+};

--- a/src/lib/i18n/leet.ts
+++ b/src/lib/i18n/leet.ts
@@ -1,0 +1,24 @@
+// Leetspeak transform: a deterministic, purely cosmetic substitution of certain
+// Latin letters with look-alike digits. Anything outside the map — other letters,
+// digits, punctuation, whitespace, markup — passes through untouched, so numbers
+// and interpolated values survive intact.
+
+const SUBSTITUTIONS: Record<string, string> = {
+	a: '4',
+	b: '8',
+	e: '3',
+	g: '9',
+	i: '1',
+	l: '1',
+	o: '0',
+	s: '5',
+	t: '7'
+};
+
+export function toLeet(input: string): string {
+	let out = '';
+	for (const ch of input) {
+		out += SUBSTITUTIONS[ch.toLowerCase()] ?? ch;
+	}
+	return out;
+}

--- a/src/lib/i18n/locale.svelte.ts
+++ b/src/lib/i18n/locale.svelte.ts
@@ -1,0 +1,52 @@
+import { isLocale, langTag, type LocaleCode } from './locales';
+import { translate } from './translate';
+
+const STORAGE_KEY = 'locale';
+
+/** Resolve the initial locale on the client: ?lang= query → localStorage → 'en'. */
+function resolveInitial(): LocaleCode {
+	if (typeof window !== 'undefined') {
+		const param = new URLSearchParams(window.location.search).get('lang');
+		if (isLocale(param)) return param;
+		try {
+			const stored = localStorage.getItem(STORAGE_KEY);
+			if (isLocale(stored)) return stored;
+		} catch {
+			// ignore storage failures (private mode, etc.)
+		}
+	}
+	return 'en';
+}
+
+class Locale {
+	current = $state<LocaleCode>(resolveInitial());
+
+	/** Switch locale from a user action: persist the choice and reflect it onto the document. */
+	set(code: LocaleCode) {
+		this.current = code;
+		this.syncDocument();
+		try {
+			localStorage.setItem(STORAGE_KEY, code);
+		} catch {
+			// ignore storage failures (private mode, etc.)
+		}
+	}
+
+	/** Reflect the current locale onto <html lang> (e.g. for a deep-linked ?lang=). */
+	syncDocument() {
+		if (typeof document !== 'undefined') {
+			document.documentElement.setAttribute('lang', langTag(this.current));
+		}
+	}
+}
+
+export const locale = new Locale();
+
+/**
+ * Translate an English source string into the active locale. Reading
+ * `locale.current` here makes every call reactive, so switching locale
+ * re-renders all `t(...)` usages.
+ */
+export function t(source: string): string {
+	return translate(source, locale.current);
+}

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -1,0 +1,30 @@
+// Locale registry. Pure (no Svelte runes) so it can be imported from Playwright
+// specs and any plain-Node context without the Svelte compiler.
+
+export type LocaleCode = 'en' | 'l33t';
+
+export interface LocaleInfo {
+	/** Internal locale identifier. */
+	code: LocaleCode;
+	/** Name shown in the switcher, written in the locale's own form (endonym). */
+	endonym: string;
+	/** BCP-47 language tag applied to <html lang>. `en-x-l33t` uses a valid private-use subtag. */
+	lang: string;
+}
+
+export const LOCALES: LocaleInfo[] = [
+	{ code: 'en', endonym: 'English', lang: 'en' },
+	{ code: 'l33t', endonym: 'L33T', lang: 'en-x-l33t' }
+];
+
+const CODES = new Set<string>(LOCALES.map((l) => l.code));
+
+/** Narrow an unknown value (query param, storage) to a known locale code. */
+export function isLocale(value: unknown): value is LocaleCode {
+	return typeof value === 'string' && CODES.has(value);
+}
+
+/** The <html lang> tag for a locale (falls back to English). */
+export function langTag(code: LocaleCode): string {
+	return LOCALES.find((l) => l.code === code)?.lang ?? 'en';
+}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1,0 +1,87 @@
+// Canonical list of every user-facing English string that has an authored
+// translation. The English source doubles as the lookup key (gettext model), and
+// `Message` is the union of these literals — so a locale catalog typed as
+// `Record<Message, string>` is checked for completeness at compile time.
+//
+// Strings intentionally left out (proper nouns such as the citation, bare
+// punctuation, and dynamic/numeric text) fall through to the per-locale fallback
+// in translate() rather than being hand-translated.
+
+export const MESSAGES = [
+	// Warning
+	'A Box',
+	'Breathing',
+	'Tool',
+	'Before you begin',
+	'A guide to the',
+	'Box Breathing',
+	'protocol from',
+	'Medical disclaimer',
+	'For educational use only. Not medical advice.',
+	'Consult a licensed physician before any breathing exercise.',
+	'Not affiliated with the study’s authors. No warranty.',
+	'I understand this is an unofficial tool offered with no warranty, and I accept full responsibility for my use of it.',
+	'Acknowledge & continue',
+	'Source code',
+	'Third-party licenses',
+
+	// App shell
+	'Carbon Dioxide Tolerance Testing & Training Tool',
+	'Back',
+	'Settle in for the exhale test.',
+	'Recover before you calibrate.',
+
+	// Exhale test
+	'Step 01 · Exhale test',
+	'Exhale as slowly as you can',
+	'Measure your slowest exhale',
+	'Tap',
+	'Stop',
+	'the moment you run out of air. Don’t hold your breath.',
+	'Inhale completely through your nose. Then start the timer and let the air out as slowly as possible.',
+	'Start',
+
+	// Calibration
+	'Step 02 · Calibration',
+	'Set your interval',
+	'Calibrated from your',
+	'exhale. Each phase will last this long.',
+	'Decrease interval',
+	'seconds',
+	'Increase interval',
+	'Start box breathing',
+
+	// Rest
+	'Breathe normally',
+	'Ideally through the nose.',
+	'Skip →',
+
+	// Box breathing
+	'Box breathing',
+	'left',
+	'Inhale',
+	'through your nose',
+	'Hold',
+	'keep it in',
+	'Exhale',
+	'slow and steady',
+	'stay empty',
+	'End session',
+
+	// Done
+	'Complete',
+	'Great job',
+	'You completed a full two-minute box-breathing cycle.',
+	'Interval',
+	'Duration',
+	'Start over',
+
+	// Theme toggle
+	'Change to light theme.',
+	'Change to dark theme.',
+
+	// Locale switcher
+	'Language'
+] as const;
+
+export type Message = (typeof MESSAGES)[number];

--- a/src/lib/i18n/translate.ts
+++ b/src/lib/i18n/translate.ts
@@ -1,0 +1,28 @@
+import { toLeet } from './leet';
+import { l33t } from './catalogs/l33t';
+import type { LocaleCode } from './locales';
+
+// Per-locale message catalogs keyed by the English source string. Adding a real
+// language is just dropping its `Record<source, translation>` in here.
+const CATALOGS: Partial<Record<LocaleCode, Record<string, string>>> = {
+	l33t
+};
+
+/**
+ * Resolve an English source string into the active locale.
+ *
+ * `en` is the identity function, which keeps the rendered English byte-identical
+ * to the pre-i18n app (the e2e suite depends on this). For other locales we look
+ * up the source in that locale's catalog. A missing entry falls back to the
+ * English source — except L33T, a constructed language, where the algorithmic
+ * leet transform fills any gap (proper nouns, punctuation, dynamic text) so it is
+ * always fully rendered.
+ */
+export function translate(source: string, locale: LocaleCode): string {
+	if (locale === 'en') return source;
+
+	const authored = CATALOGS[locale]?.[source];
+	if (authored !== undefined) return authored;
+
+	return locale === 'l33t' ? toLeet(source) : source;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import '../app.css';
+	import { locale } from '$lib/i18n/locale.svelte';
+
 	let { children } = $props();
+
+	// Reflect the resolved locale (e.g. a deep-linked ?lang=) onto <html lang>
+	// once the client is live. Done in onMount, not an $effect, to keep the
+	// imperative DOM write out of reactive tracking.
+	onMount(() => locale.syncDocument());
 </script>
 
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,19 +6,25 @@
 	import BoxBreathing from '$lib/BoxBreathing.svelte';
 	import Done from '$lib/Done.svelte';
 	import ThemeToggle from '$lib/ThemeToggle.svelte';
+	import LocaleSwitcher from '$lib/LocaleSwitcher.svelte';
 	import Wordmark from '$lib/Wordmark.svelte';
 	import Pips from '$lib/Pips.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import { createSession, PIP_TOTAL } from '$lib/session.svelte';
+	import { t } from '$lib/i18n/locale.svelte';
 
 	const session = createSession();
 </script>
+
+<svelte:head>
+	<title>{t('Carbon Dioxide Tolerance Testing & Training Tool')}</title>
+</svelte:head>
 
 <div class="app">
 	<header class="appbar">
 		<div class="bar-side">
 			{#if session.canBack}
-				<button class="icon-btn" aria-label="Back" onclick={() => session.back()}>
+				<button class="icon-btn" aria-label={t('Back')} onclick={() => session.back()}>
 					<Icon name="back" size={19} />
 				</button>
 			{:else}
@@ -27,6 +33,7 @@
 		</div>
 		<Pips total={PIP_TOTAL} idx={session.pipIndex} />
 		<div class="bar-side right">
+			<LocaleSwitcher />
 			<ThemeToggle />
 		</div>
 	</header>
@@ -38,7 +45,7 @@
 					<Warning onAccept={() => session.advance()} />
 				{:else if session.current === 'rest1'}
 					<Reset
-						sub="Settle in for the exhale test."
+						sub={t('Settle in for the exhale test.')}
 						onDone={() => session.advance()}
 						onSkip={() => session.advance()}
 					/>
@@ -51,7 +58,7 @@
 					/>
 				{:else if session.current === 'rest2'}
 					<Reset
-						sub="Recover before you calibrate."
+						sub={t('Recover before you calibrate.')}
 						onDone={() => session.advance()}
 						onSkip={() => session.advance()}
 					/>


### PR DESCRIPTION
## What

Adds internationalization infrastructure and lands **L33T** (leetspeak) as the first real secondary language.

### Core design
- **English source string is the key** (gettext model). `translate(source, 'en')` is the **identity function**, so rendered English is byte-identical to before — the existing ~143-assertion e2e suite passes **unchanged**.
- `src/lib/i18n/` splits **pure, runes-free** modules (`leet.ts`, `translate.ts`, `locales.ts`, `messages.ts`, `catalogs/l33t.ts`) from the single reactive `locale.svelte.ts` — so the pure logic imports directly into Playwright specs without the Svelte compiler.
- **Reactive locale singleton** mirroring `theme.svelte.ts`: resolves `?lang=` → `localStorage` → `en`, syncs `<html lang>` in `onMount`.
- **Visible header switcher** (`LocaleSwitcher.svelte`) next to the theme toggle.

### L33T as a real, data-driven language
- `messages.ts` — canonical `MESSAGES` list + `Message` type.
- `catalogs/l33t.ts` — hand-authored `Record<Message, string>`; **completeness enforced at compile time** by `svelte-check` (missing/stray key = type error).
- `translate()` is a generic per-locale catalog lookup (English-source fallback); `toLeet()` only fills gaps for L33T (citation, punctuation, numbers). A future human language is one catalog drop into `CATALOGS`.

### Also
- All user-facing copy, aria-labels, and the page `<title>` wrapped in `t()` (transform everything); title moved into `<svelte:head>`.
- Fixes a **latent eslint flat-config gap**: `*.svelte.ts` / `*.svelte.js` runes modules weren't parsed with TypeScript, so `npm run lint` was already failing on `main` (the Integration run for the commit that introduced those modules is red). One-line `files` glob fix.

## Tests
- `e2e/i18n-transform.test.ts` — pure transform/identity/fallback checks.
- `e2e/i18n-catalog.test.ts` — catalog completeness, real-translation, no-orphans.
- `e2e/i18n.test.ts` — deep-link `?lang=l33t`, live switch + persistence, full flow in L33T (locale-aware selectors), unknown-`?lang=` fallback.

**Verification:** `svelte-check` 0 errors · lint clean · **60/60 e2e pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)